### PR TITLE
Set -j 0 as default

### DIFF
--- a/parallelforeachsubmodule/pfs.py
+++ b/parallelforeachsubmodule/pfs.py
@@ -41,7 +41,7 @@ class PFS(object):
                             type=lambda s: s.upper())
         parser.add_argument('-j', '--jobs', dest='jobs',
                             help='Number of concurrent jobs. Use -j 0 to use automatically the best maximum number of jobs',
-                            type=self.valid_jobs, default=2)
+                            type=self.valid_jobs, default=0)
         parser.add_argument('--pull', dest='pull', action='store_true',
                             help='Shortcut to "git pull origin"')
         parser.add_argument('--pending', dest='pending', action='store_true',

--- a/parallelforeachsubmodule/pfs.py
+++ b/parallelforeachsubmodule/pfs.py
@@ -41,7 +41,7 @@ class PFS(object):
                             type=lambda s: s.upper())
         parser.add_argument('-j', '--jobs', dest='jobs',
                             help='Number of concurrent jobs. Use -j 0 to use automatically the best maximum number of jobs',
-                            type=self.valid_jobs, default=0)
+                            type=self.valid_jobs, default=multiprocessing.cpu_count())
         parser.add_argument('--pull', dest='pull', action='store_true',
                             help='Shortcut to "git pull origin"')
         parser.add_argument('--pending', dest='pending', action='store_true',


### PR DESCRIPTION
Set the default number of jobs to 0 so it uses a number of threads equal to the number of processors. This highly improves the default execution speed.